### PR TITLE
Add diagnosticid and  codeFixIndex parameters to TestCodeFix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ analyzers, code fixes and refactorings using NUnit.
 
 ### Quick Start
 
-1. Install the [RoslynNUnitLight](https://www.nuget.org/packages/RoslynNUnitLight.NetStandard)
+1. Install the [RoslynNUnitLight.NetStandard](https://www.nuget.org/packages/RoslynNUnitLight.NetStandard)
    package from NuGet into your project.
 2. Create a new class that inherits from one of the provided ```*TestFixture```
    classes that matches what are going to test.
@@ -88,6 +88,7 @@ class C
     TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseGetterOnlyAutoProperty);
 }
 ```
+Instead of the diagnostic descriptor, you can also use Diagnostic Id (error code) to identify the issue which should be fixed by tested code fix. This allows testing code fixes which respond to standard C# compiler errors such as `CS0736`.
 
 #### Example: Test code refactoring behavior
 

--- a/RoslynNUnitLight.NetStandard/CodeFixTestFixture.cs
+++ b/RoslynNUnitLight.NetStandard/CodeFixTestFixture.cs
@@ -15,7 +15,7 @@ namespace RoslynNUnitLight
     {
         protected abstract CodeFixProvider CreateProvider();
 
-        protected void TestCodeFix(string markupCode, string expected, string diagnosticId)
+        protected void TestCodeFix(string markupCode, string expected, string diagnosticId, int codeFixIndex = 0)
         {
             var (document, span) = GetDocumentAndSpanFromMarkup(markupCode);
             var reportedDiagnostics = GetReportedDiagnostics(document).ToList();
@@ -25,21 +25,20 @@ namespace RoslynNUnitLight
                 var reportedIssues = reportedDiagnostics.Select(x => x.Id).ToList();
                 return $"There is no issue reported for {diagnosticId}. Reported issues: {string.Join(",", reportedIssues)}";
             });
-            TestCodeFix(document, span, expected, diagnostic.Descriptor);
+            TestCodeFix(document, span, expected, diagnostic.Descriptor, codeFixIndex);
         }
 
-        protected void TestCodeFix(string markupCode, string expected, DiagnosticDescriptor descriptor)
+        protected void TestCodeFix(string markupCode, string expected, DiagnosticDescriptor descriptor, int codeFixIndex = 0)
         {
             var (document, span) = GetDocumentAndSpanFromMarkup(markupCode);
-            TestCodeFix(document, span, expected, descriptor);
+            TestCodeFix(document, span, expected, descriptor, codeFixIndex);
         }
 
-        protected void TestCodeFix(Document document, TextSpan span, string expected, DiagnosticDescriptor descriptor)
+        protected void TestCodeFix(Document document, TextSpan span, string expected, DiagnosticDescriptor descriptor, int codeFixIndex = 0)
         {
             var codeFixes = GetCodeFixes(document, span, descriptor);
-            Assert.That(codeFixes.Length, Is.EqualTo(1));
-
-            Verify.CodeAction(codeFixes[0], document, expected);
+            Assert.That(codeFixes.Length, Is.AtLeast(codeFixIndex + 1));
+            Verify.CodeAction(codeFixes[codeFixIndex], document, expected);
         }
 
         private (Document document, TextSpan span) GetDocumentAndSpanFromMarkup(string markupCode)

--- a/RoslynNUnitLight.NetStandard/CodeFixTestFixture.cs
+++ b/RoslynNUnitLight.NetStandard/CodeFixTestFixture.cs
@@ -43,7 +43,7 @@ namespace RoslynNUnitLight
 
         private (Document document, TextSpan span) GetDocumentAndSpanFromMarkup(string markupCode)
         {
-            Assert.That(TestHelpers.TryGetDocumentAndSpanFromMarkup(markupCode, LanguageName, out var document, out var span), Is.True);
+            Assert.That(TestHelpers.TryGetDocumentAndSpanFromMarkup(markupCode, LanguageName, out var document, out var span), Is.True, "Cannot find any text span marked with '[||]'");
             return (document, span);
         }
 


### PR DESCRIPTION
Hi

This PR allows to test easily CodeFIxProviders that respond to C# compiler errors (`diagnosticid `). 
Thanks to `codeFixIndex` it's possible now to verify test cases that reports more than one code fix in marked text span.